### PR TITLE
fix: prevent duplicate UnrecoverableError log

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -664,7 +664,6 @@ func run(ctx context.Context, request AnyRequest, m *Manager, r runner, ri *runI
 				localActionCounterVec.WithLabelValues("unrecoverable", kind).Inc()
 				localActionDurationVec.WithLabelValues("unrecoverable", "").Observe(time.Since(actionStartTime).Seconds())
 				span.SetAttributes(attribute.String("fsm.error_kind", kind))
-				logger.WithError(err).Error("reached unrecoverable error, canceling FSM")
 			case errors.As(err, &he):
 				localActionCounterVec.WithLabelValues("fsm_handoff_error", "").Inc()
 				localActionDurationVec.WithLabelValues("fsm_handoff_error", "").Observe(time.Since(actionStartTime).Seconds())


### PR DESCRIPTION
Hey 👋

I noticed that the `UnrecoverableError` was being logged twice.

```
INFO[0000] executing                                     inflight=1 queue=default queued=0 size=5
INFO[0000] Started FSM with ID: 01K554SZCZBZ86JYF5RD3Q4DCM 
INFO[0000] running queued function                       run_alias=image_request run_id=1 run_type=ImageRequest run_version=01K554SZCZBZ86JYF5RD3Q4DCM sys=fsm
INFO[0000] starting fsm                                  run_alias=image_request run_id=1 run_type=ImageRequest run_version=01K554SZCZBZ86JYF5RD3Q4DCM sys=fsm
INFO[0000] running transition                            run_alias=image_request run_id=1 run_type=ImageRequest run_version=01K554SZCZBZ86JYF5RD3Q4DCM sys=fsm transition=init transition_version=01K554SZDH9ZFDD9CCT2938VN2
INFO[0000] transition completed successfully             run_alias=image_request run_id=1 run_type=ImageRequest run_version=01K554SZCZBZ86JYF5RD3Q4DCM sys=fsm transition=init transition_version=01K554SZDH9ZFDD9CCT2938VN2
INFO[0000] running transition                            run_alias=image_request run_id=1 run_type=ImageRequest run_version=01K554SZCZBZ86JYF5RD3Q4DCM sys=fsm transition=fetch transition_version=01K554SZE1ATVT0X7FCNW3DWP0
ERRO[0000] reached unrecoverable error, canceling FSM    error="failed to download image from blob: operation error S3: GetObject, https response error StatusCode: 404, RequestID: X5QAZA46T1YH9B1T, HostID: 5FRGvGR/iZWzyIwCgknU3izdXXVRryqf49/eFlas38rGO7GvSbOTJjlQ23TbrZm/EvkeX/bRDrvIPoilXQwRFUs/1KW/5sGZtChDX27odCU=, NoSuchKey: " run_alias=image_request r
un_id=1 run_type=ImageRequest run_version=01K554SZCZBZ86JYF5RD3Q4DCM sys=fsm transition=fetch transition_version=01K554SZE1ATVT0X7FCNW3DWP0
INFO[0000] transition returned cancelable error, completing run  error="failed to download image from blob: operation error S3: GetObject, https response error StatusCode: 404, RequestID: X5QAZA46T1YH9B1T, HostID: 5FRGvGR/iZWzyIwCgknU3izdXXVRryqf49/eFlas38rGO7GvSbOTJjlQ23TbrZm/EvkeX/bRDrvIPoilXQwRFUs/1KW/5sGZtChDX27odCU=, NoSuchKey: " run_alias=image_r
equest run_id=1 run_type=ImageRequest run_version=01K554SZCZBZ86JYF5RD3Q4DCM sys=fsm transition=fetch transition_version=01K554SZE1ATVT0X7FCNW3DWP0
ERRO[0000] reached unrecoverable error, canceling FSM    error="failed to download image from blob: operation error S3: GetObject, https response error StatusCode: 404, RequestID: X5QAZA46T1YH9B1T, HostID: 5FRGvGR/iZWzyIwCgknU3izdXXVRryqf49/eFlas38rGO7GvSbOTJjlQ23TbrZm/EvkeX/bRDrvIPoilXQwRFUs/1KW/5sGZtChDX27odCU=, NoSuchKey: " run_alias=image_request r
un_id=1 run_type=ImageRequest run_version=01K554SZCZBZ86JYF5RD3Q4DCM sys=fsm transition=fetch transition_version=01K554SZE1ATVT0X7FCNW3DWP0
```

I suppose that this should handled like the other errors, only in `interceptor.go` instead of `fsm.go`.